### PR TITLE
Use Kokkos::sqrt instead of Experimental for Kokkos 4.0

### DIFF
--- a/src/ParticleActions.cxx
+++ b/src/ParticleActions.cxx
@@ -115,7 +115,11 @@ void ParticleActions::updateVel(\
             if (dist2 < rmax2) 
             {
               const float dist2Err = dist2 + rsm2;
-              const float tmp =  1.0f/Kokkos::Experimental::sqrt(dist2Err*dist2Err*dist2Err) - FGridEvalPoly(dist2);
+#if KOKKOS_VERSION >= 40000
+               1.0f/Kokkos::sqrt(dist2Err*dist2Err*dist2Err) - FGridEvalPoly(dist2);
+#else
+              const float tmp = 1.0f/Kokkos::Experimental::sqrt(dist2Err*dist2Err*dist2Err) - FGridEvalPoly(dist2);
+#endif
               force[0] += dx * tmp;
               force[1] += dy * tmp;
               force[2] += dz * tmp;


### PR DESCRIPTION
Not tested, but may fix #10.