### PR TITLE
Neighbor parallel

### DIFF
--- a/src/ParticleActions.cxx
+++ b/src/ParticleActions.cxx
@@ -46,7 +46,7 @@ void ParticleActions::setParticles(Particles *P_)
 
 // Stream
 void ParticleActions::updatePos(\
-    Cabana::AoSoA<HACCabana::Particles::data_types, device_type, VECTOR_LENGTH> aosoa_device,\
+    Cabana::AoSoA<HACCabana::Particles::data_types, device_mem, VECTOR_LENGTH> aosoa_device,\
     float prefactor)
 {
   auto position = Cabana::slice<HACCabana::Particles::Fields::Position>(aosoa_device, "position");
@@ -63,8 +63,8 @@ void ParticleActions::updatePos(\
 
 // Kick
 void ParticleActions::updateVel(\
-    Cabana::AoSoA<HACCabana::Particles::data_types, device_type, VECTOR_LENGTH> aosoa_device,\
-    Cabana::LinkedCellList<device_type> cell_list,\
+    Cabana::AoSoA<HACCabana::Particles::data_types, device_mem, VECTOR_LENGTH> aosoa_device,\
+    Cabana::LinkedCellList<device_mem> cell_list,\
     const float c, const float rmax2, const float rsm2)
 {
   auto position = Cabana::slice<HACCabana::Particles::Fields::Position>(aosoa_device, "position");
@@ -140,7 +140,7 @@ void ParticleActions::subCycle(TimeStepper &ts, const int nsub, const float gpsc
     const float cm_size, const float min_pos, const float max_pos)
 {
   // copy particles to GPU
-  Cabana::AoSoA<HACCabana::Particles::data_types, device_type, VECTOR_LENGTH> aosoa_device("aosoa_device", P->num_p);
+  Cabana::AoSoA<HACCabana::Particles::data_types, device_mem, VECTOR_LENGTH> aosoa_device("aosoa_device", P->num_p);
   Cabana::deep_copy(aosoa_device, P->aosoa_host);
 
   // create the cell list on the GPU
@@ -154,7 +154,7 @@ void ParticleActions::subCycle(TimeStepper &ts, const int nsub, const float gpsc
   float grid_max[3] = {x_max, x_max, x_max};
 
   auto position = Cabana::slice<HACCabana::Particles::Fields::Position>(aosoa_device, "position");
-  Cabana::LinkedCellList<device_type> cell_list(position, P->begin, P->end, grid_delta, grid_min, grid_max);
+  Cabana::LinkedCellList<device_mem> cell_list(position, P->begin, P->end, grid_delta, grid_min, grid_max);
   Cabana::permute(cell_list, aosoa_device);
   Kokkos::fence();
 

--- a/src/ParticleActions.h
+++ b/src/ParticleActions.h
@@ -22,8 +22,6 @@ namespace HACCabana
   public:
     using device_exec = Kokkos::DefaultExecutionSpace::execution_space;
     using device_mem = Kokkos::DefaultExecutionSpace::memory_space;
-    using device_type = Kokkos::Device<device_exec, device_mem>;
-    //using device_scratch = Kokkos::ScratchMemorySpace<device_exec>;
 
     ParticleActions();
     ParticleActions(Particles *P_);
@@ -31,10 +29,10 @@ namespace HACCabana
     void setParticles(Particles *P_);
     void subCycle(TimeStepper &ts, const int nsub, const float gpscal, const float rmax2, const float rsm2,\
         const float cm_size, const float min_pos, const float max_pos);
-    void updatePos(Cabana::AoSoA<HACCabana::Particles::data_types, device_type, VECTOR_LENGTH> aosoa_device,\
+    void updatePos(Cabana::AoSoA<HACCabana::Particles::data_types, device_mem, VECTOR_LENGTH> aosoa_device,\
         float prefactor);
-    void updateVel(Cabana::AoSoA<HACCabana::Particles::data_types, device_type, VECTOR_LENGTH> aosoa_device,\
-        Cabana::LinkedCellList<device_type> cell_list,\
+    void updateVel(Cabana::AoSoA<HACCabana::Particles::data_types, device_mem, VECTOR_LENGTH> aosoa_device,\
+        Cabana::LinkedCellList<device_mem> cell_list,\
         const float c, const float rmax2, const float rsm2);
   };
 }

--- a/src/ParticleActions.h
+++ b/src/ParticleActions.h
@@ -32,7 +32,7 @@ namespace HACCabana
     void updatePos(Cabana::AoSoA<HACCabana::Particles::data_types, device_mem, VECTOR_LENGTH> aosoa_device,\
         float prefactor);
     void updateVel(Cabana::AoSoA<HACCabana::Particles::data_types, device_mem, VECTOR_LENGTH> aosoa_device,\
-        Cabana::LinkedCellList<device_mem> cell_list,\
+        Cabana::LinkedCellList<device_mem, float> cell_list,\
         const float c, const float rmax2, const float rsm2);
   };
 }

--- a/src/Particles.h
+++ b/src/Particles.h
@@ -18,10 +18,9 @@ namespace HACCabana
         ParticleID = 0,
         Position = 1,
         Velocity = 2,
-        BinIndex = 3
       };
 
-      using data_types = Cabana::MemberTypes<int64_t, float[3], float[3], int>;
+      using data_types = Cabana::MemberTypes<int64_t, float[3], float[3]>;
       using aosoa_host_type = Cabana::AoSoA<data_types, Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>>;
 
       size_t num_p = 0;


### PR DESCRIPTION
Replace internal iteration over linked cell bins with `Cabana::neighbor_parallel_for`. Need to look into the best way to incorporate the `access(s,a)` inside this kernel

Depends on ECP-CoPA/Cabana#712