### PR TITLE
CI: run on ubuntu-latest

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         distro: ['ubuntu:latest']
         backend: ["SERIAL", "OPENMP"]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/ecp-copa/ci-containers/${{ matrix.distro }}
     steps:


### PR DESCRIPTION
20.04 is being retired; avoid having to do this in the future with latest
